### PR TITLE
Feature/vgrid vs arrays shape

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -212,11 +212,11 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     environment:
       # TODO: next is for prod pypi; comment for tests
-      name: pypi
-      url: https://pypi.org/p/deker
+#      name: pypi
+#      url: https://pypi.org/p/deker
       # TODO: next is for test pypi; comment for prod
-      # name: testpypi
-      # url: https://test.pypi.org/p/deker
+      name: testpypi
+      url: https://test.pypi.org/p/deker
 
     steps:
       - uses: actions/download-artifact@v3
@@ -229,5 +229,5 @@ jobs:
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         # TODO: next is for test pypi; comment for prod
-        # with:
-          # repository-url: https://test.pypi.org/legacy/
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -152,6 +152,7 @@ jobs:
       image: ghcr.io/openweathermap/deker/deker-embedded/tox:latest
       env:
         PACKAGE_VERSION: ${{ github.REF_NAME }}
+        PIP_EXTRA_INDEX_URL: https://test.pypi.org/simple/
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -163,11 +164,15 @@ jobs:
         uses: actions/checkout@v2
       - name: Install tox
         run: |
+          env
           pip install tox
         env:
           PIP_DISABLE_PIP_VERSION_CHECK: 1
+          PIP_EXTRA_INDEX_URL: https://test.pypi.org/simple/
       - name: Run tox tests
-        run: tox
+        run: |
+          env
+          tox
         env:
           PIP_DISABLE_PIP_VERSION_CHECK: 1
           PACKAGE_VERSION: ${{ github.REF_NAME }}

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -171,6 +171,7 @@ jobs:
         env:
           PIP_DISABLE_PIP_VERSION_CHECK: 1
           PACKAGE_VERSION: ${{ github.REF_NAME }}
+          PIP_EXTRA_INDEX_URL: https://test.pypi.org/simple/
 
   build_wheels:
     name: Build wheels on ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [![PyPI pyversions](https://img.shields.io/pypi/pyversions/deker.svg)](https://pypi.python.org/pypi/deker/)
 [![PyPI version shields.io](https://img.shields.io/pypi/v/deker.svg)](https://pypi.python.org/pypi/deker/)
-[![GitHub license](https://badgen.net/github/license/openweathermap/deker)](https://github.com/openweathermap/deker/blob/master/LICENSE)  
+[![GitHub license](https://badgen.net/github/license/openweathermap/deker)](https://github.com/openweathermap/deker/blob/main/LICENSE)  
 [![pipeline](https://github.com/openweathermap/deker/actions/workflows/github-actions.yml/badge.svg)](https://github.com/openweathermap/deker/actions/workflows/github-actions.yml)
 [![docs](https://github.com/openweathermap/deker/actions/workflows/docs.yml/badge.svg)](https://github.com/openweathermap/deker/actions/workflows/docs.yml)
 

--- a/deker/arrays.py
+++ b/deker/arrays.py
@@ -252,7 +252,7 @@ class VArray(BaseArray):
     @property
     def arrays_shape(self) -> Tuple[int, ...]:
         """Get the shape of inner ``Arrays``."""
-        return self.schema.arrays_shape
+        return self.schema.arrays_shape  # type: ignore[return-value]
 
     @property
     def as_dict(self) -> dict:

--- a/deker/collection.py
+++ b/deker/collection.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Generator, Optional, Type, Union
 
 from deker.ABC.base_adapters import BaseCollectionAdapter, BaseStorageAdapter
 from deker.ABC.base_collection import BaseCollectionOptions
+from deker.arrays import Array, VArray
 from deker.errors import (
     DekerInstanceNotExistsError,
     DekerInvalidManagerCallError,
@@ -35,14 +36,13 @@ from deker.schemas import (
     TimeDimensionSchema,
     VArraySchema,
 )
-from deker.tools import check_memory, create_array_from_meta, not_deleted
+from deker.tools import check_memory, not_deleted
 from deker.types import Serializer
 from deker.types.private.enums import SchemaType
 
 
 if TYPE_CHECKING:
     from deker.ABC.base_factory import BaseAdaptersFactory
-    from deker.arrays import Array, VArray
 
 
 class Collection(SelfLoggerMixin, Serializer):
@@ -262,7 +262,7 @@ class Collection(SelfLoggerMixin, Serializer):
     @not_deleted
     def create(
         self, primary_attributes: Optional[dict] = None, custom_attributes: Optional[dict] = None
-    ) -> Union["Array", "VArray"]:
+    ) -> Union[Array, VArray]:
         """Create ``Array`` or ``VArray`` according to collection main schema.
 
         If ``VArraySchema`` is passed to ``Collection``, all data management will go through ``VArrays``
@@ -317,7 +317,7 @@ class Collection(SelfLoggerMixin, Serializer):
     def __next__(self) -> None:
         pass
 
-    def __iter__(self) -> Generator[Union["Array", "VArray"], None, None]:
+    def __iter__(self) -> Generator[Union[Array, VArray], None, None]:
         """Yield ``VArrays`` or ``VArrays`` from the ``Collection``."""
         if self._is_deleted():
             raise DekerInstanceNotExistsError(
@@ -336,7 +336,12 @@ class Collection(SelfLoggerMixin, Serializer):
 
         self.logger.debug(f"Iterating over collection {self.name}")
         for meta in adapter:
-            array = create_array_from_meta(self, meta, array_adapter, varray_adapter=varray_adapter)
+            if varray_adapter:
+                array: VArray = VArray._create_from_meta(
+                    self, meta, array_adapter, varray_adapter=varray_adapter
+                )
+            else:
+                array: Array = Array._create_from_meta(self, meta, array_adapter)
             yield array
 
     def __repr__(self) -> str:

--- a/deker/managers.py
+++ b/deker/managers.py
@@ -20,7 +20,6 @@ from deker.ABC.base_managers import BaseAbstractManager, BaseManager
 from deker.arrays import Array, VArray
 from deker.log import SelfLoggerMixin
 from deker.schemas import VArraySchema
-from deker.tools import create_array_from_meta
 
 
 if TYPE_CHECKING:
@@ -192,7 +191,7 @@ class VArrayManager(SelfLoggerMixin, DataManager):
         """Yield VArrays from adapter."""
         self.logger.debug("iterating over VArrays")
         for meta in self._adapter:  # type: ignore[attr-defined]
-            yield create_array_from_meta(
+            yield VArray._create_from_meta(
                 self.__collection, meta, self.__array_adapter, self.__varray_adapter
             )
 
@@ -238,6 +237,4 @@ class ArrayManager(SelfLoggerMixin, DataManager):
         """Yield Arrays from adapter."""
         self.logger.debug("iterating over Arrays")
         for meta in self._adapter:  # type: ignore[attr-defined]
-            yield create_array_from_meta(
-                self.__collection, meta, self.__array_adapter, self.__varray_adapter
-            )
+            yield Array._create_from_meta(self.__collection, meta, self.__array_adapter)

--- a/deker/schemas.py
+++ b/deker/schemas.py
@@ -314,9 +314,16 @@ class VArraySchema(SelfLoggerMixin, BaseArraysSchema):
 
     :param vgrid: an ordered sequence of positive integers; used for splitting ``VArray`` into ordinary ``Arrays``.
 
+      Each VArray dimension "size" shall be divided by the correspondent integer without remainders, thus an
+      ``Array's`` shape is created. If there is no need to split any dimension, its vgrid positional integer
+      shall be ``1``.
+
+    :param arrays_shape: an ordered sequence of positive integers; used for setting the shape of ordinary ``Arrays``
+      laying under a ``VArray``.
+
       Each integer in the sequence represents the total quantity of cells in the correspondent dimension
-      of each ordinary array. Each varray dimension "size" shall be divided by the correspondent integer
-      without remainders. If there is no need to split any dimension, its vgrid positional integer shall be ``1``.
+      of each ordinary ``Array``. Each ``VArray`` dimension "size" shall be divided by the correspondent integer
+      without remainders, thus a ``VArray's`` vgrid is created.
 
     :param fill_value: an optional value for filling in empty cells;
       If ``None`` - default value for each dtype will be used. Numpy ``nan`` can be used only for floating numpy dtypes.

--- a/deker/tools/__init__.py
+++ b/deker/tools/__init__.py
@@ -19,7 +19,6 @@ from .array import (
     calculate_total_cells_in_array,
     check_memory,
     convert_human_memory_to_bytes,
-    create_array_from_meta,
     get_id,
 )
 from .decorators import not_deleted

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ typing-extensions>=4.4.0
 tqdm>=4.64.1
 psutil>=5.9.5
 
+--extra-index-url https://test.pypi.org/simple/
 deker-local-adapters==1.0.1b

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,4 @@ typing-extensions>=4.4.0
 tqdm>=4.64.1
 psutil>=5.9.5
 
---extra-index-url https://test.pypi.org/simple/
 deker-local-adapters==1.0.1b

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ typing-extensions>=4.4.0
 tqdm>=4.64.1
 psutil>=5.9.5
 
-deker-local-adapters==1.0.0
+--extra-index https://test.pypi.org/simple/
+deker-local-adapters==1.0.1b

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ typing-extensions>=4.4.0
 tqdm>=4.64.1
 psutil>=5.9.5
 
---extra-index https://test.pypi.org/simple/ deker-local-adapters==1.0.1b
+--extra-index https://test.pypi.org/simple/
+deker-local-adapters==1.0.1b

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,4 @@ typing-extensions>=4.4.0
 tqdm>=4.64.1
 psutil>=5.9.5
 
---extra-index https://test.pypi.org/simple/
-deker-local-adapters==1.0.1b
+--extra-index https://test.pypi.org/simple/ deker-local-adapters==1.0.1b

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ typing-extensions>=4.4.0
 tqdm>=4.64.1
 psutil>=5.9.5
 
---extra-index https://test.pypi.org/simple/
+--extra-index-url https://test.pypi.org/simple/
 deker-local-adapters==1.0.1b

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,7 +78,7 @@ def root_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
 
     :param tmp_path_factory:  Temporary directory factory
     """
-    if path := os.getenv('ROOT_PATH'):
+    if path := os.getenv("ROOT_PATH"):
         directory = Path(path)
     else:
         directory = tmp_path_factory.mktemp("test", numbered=False)

--- a/tests/parameters/schemas_params.py
+++ b/tests/parameters/schemas_params.py
@@ -558,6 +558,7 @@ class VArraySchemaCreationParams(SchemaParams, TypedSchemaParams):
         """Returns wrong params for array_schema."""
         dimensions, dtype = cls._get_dims_dtype()
         vgrid = (1, 1, 1)
+        arrays_shape = (10, 10, 10)
 
         return [
             # wrong dtype
@@ -576,6 +577,19 @@ class VArraySchemaCreationParams(SchemaParams, TypedSchemaParams):
                 key="vgrid",
                 exception_types=[tuple, list],
             ),
+            # wrong arrays_shape
+            *cls._generate_types(
+                base_dict={"dtype": dtype, "dimensions": dimensions},
+                key="arrays_shape",
+                exception_types=[tuple, list],
+            ),
+            # vgrid and arrays_shape at the same time
+            {
+                "dtype": dtype,
+                "dimensions": dimensions,
+                "vgrid": vgrid,
+                "arrays_shape": arrays_shape,
+            },
         ]
 
 

--- a/tests/test_cases/test_local_adapters_package/test_array_adapter.py
+++ b/tests/test_cases/test_local_adapters_package/test_array_adapter.py
@@ -16,7 +16,7 @@ from deker.client import Client
 from deker.collection import Collection
 from deker.errors import DekerArrayError, DekerArrayTypeError, DekerValidationError
 from deker.schemas import ArraySchema, DimensionSchema
-from deker.tools import create_array_from_meta, get_paths
+from deker.tools import get_paths
 
 
 class TestArrayAdapter:
@@ -354,7 +354,7 @@ class TestArrayAdapter:
         adapter.update_meta_custom_attributes(array_with_attributes, new_custom_attributes)
         assert array_with_attributes.custom_attributes == new_custom_attributes
         meta = array_with_attributes.read_meta()
-        ar = create_array_from_meta(
+        ar = Array._create_from_meta(
             array_with_attributes._Array__collection,  # type: ignore[attr-defined]
             meta,  # type: ignore[arg-type]
             array_with_attributes._adapter,

--- a/tests/test_cases/test_local_adapters_package/test_varray_adapter.py
+++ b/tests/test_cases/test_local_adapters_package/test_varray_adapter.py
@@ -11,7 +11,7 @@ from deker_tools.path import is_empty
 from deker.arrays import VArray
 from deker.collection import Collection
 from deker.errors import DekerArrayError, DekerValidationError
-from deker.tools import create_array_from_meta, get_paths
+from deker.tools import get_paths
 
 
 class TestVArrayAdapterMethods:
@@ -136,17 +136,16 @@ class TestVArrayAdapterMethods:
             "custom_attribute": 0.6,
             "time_attr_name": datetime.now(timezone.utc),
         }
-        adapter: LocalVArrayAdapter = varray_with_attributes._adapter
+        adapter: LocalVArrayAdapter = varray_with_attributes._adapter  # type: ignore[attr-defined]
         adapter.create(varray_with_attributes)
         adapter.update_meta_custom_attributes(varray_with_attributes, new_custom_attributes)
         assert varray_with_attributes.custom_attributes == new_custom_attributes
         meta = varray_with_attributes.read_meta()
-        ar = create_array_from_meta(
+        ar = VArray._create_from_meta(
             varray_with_attributes._VArray__collection,  # type: ignore[attr-defined]
             meta,  # type: ignore[arg-type]
             varray_adapter=adapter,
-            array_adapter=varray_with_attributes._VArray__array_adapter,
-            # type: ignore[attr-defined]
+            array_adapter=varray_with_attributes._VArray__array_adapter,  # type: ignore[attr-defined]
         )
         assert ar.custom_attributes == new_custom_attributes
 

--- a/tests/test_cases/test_schemas/test_attributes_schema.py
+++ b/tests/test_cases/test_schemas/test_attributes_schema.py
@@ -14,7 +14,6 @@ from deker.collection import Collection
 from deker.dimensions import Dimension, TimeDimension
 from deker.errors import DekerValidationError
 from deker.schemas import ArraySchema, AttributeSchema
-from deker.tools import create_array_from_meta
 from deker.types.private.typings import NumericDtypes
 
 
@@ -196,7 +195,7 @@ def test_schema_conversion(
     assert isinstance(meta[key]["units"], list)
     assert isinstance(meta[key]["dt"], str)
 
-    array = create_array_from_meta(col, meta, local_array_adapter)
+    array = Array._create_from_meta(col, meta, local_array_adapter)
     assert isinstance(getattr(array, key)["units"], tuple)
     assert isinstance(getattr(array, key)["dt"], datetime)
 


### PR DESCRIPTION
VArray shape may be split either by `vgrid` or by `arrays_shape` argument:
- `vgrid` splits VArray shape and creates the shape of all underlying Arrays
- `arrays_shape` sets the shape of all underlying Arrays and creates vgrid
